### PR TITLE
fix(bc-footer): Fix Mobile Margins Between Submenus

### DIFF
--- a/packages/cx-navigation/src/components/SubMenu/tokens/cxSubMenu.ts
+++ b/packages/cx-navigation/src/components/SubMenu/tokens/cxSubMenu.ts
@@ -28,7 +28,7 @@ const Footer = asSubMenuToken(Base, {
   },
   Spacing: {
     Wrapper: 'lg:mb-16',
-    Item: 'mt-5 lg:mt-3 lg:first:mt-6',
+    Item: 'mt-6 first:mt-3 lg:mt-3 lg:first:mt-6',
     Title: 'my-3 lg:my-1.5',
   },
 });


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md), especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/Bodiless-JS/issues/new). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Angular Commit Message Conventions. Please see (https://github.com/johnsonandjohnson/Bodiless-JS/blob/main/packages/bodiless-documentation/doc/Development/Contributing.md) for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->

## Test Instructions
<!-- Detailed description of how this feature was (and should be) tested
  - Setup instructions (if any)?
  - List of test cases, with steps and expected results?
  - List
-->

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
